### PR TITLE
Don't use sudo with pip

### DIFF
--- a/docker-forward
+++ b/docker-forward
@@ -21,7 +21,7 @@ try:
     from lockfile import LockTimeout
 except ImportError:
     sys.exit('Python module python-daemon is not installed!\n'
-             'Please run `sudo easy_install pip && sudo pip install python-daemon`')
+             'Please run `pip install --user python-daemon`')
 
 try:
     from docker.client import APIClient
@@ -30,7 +30,7 @@ try:
     from requests.exceptions import ConnectionError
 except ImportError:
     sys.exit('Python module docker is not installed!\n'
-             'Please run `sudo easy_install pip && sudo pip install docker`')
+             'Please run `pip install --user docker`')
 
 VERSION = "v1.2.3"
 TMP_DIR = "/tmp/"


### PR DESCRIPTION
Using pip with builtin python
```
curl -O https://bootstrap.pypa.io/get-pip.py
python get-pip.py --user
python -m pip install --user docker python-daemon
```

Using pip with brew python
```
brew install python2
echo 'PATH="/usr/local/opt/python/libexec/bin:$PATH"' >> ~/.bash_profile
source ~/.bash_profile
pip2 install --user docker python-daemon
```