### PR TITLE
Increase docker event timeouts.

### DIFF
--- a/docker-forward
+++ b/docker-forward
@@ -179,7 +179,7 @@ class App():
             logging.info("Using DOCKER_CERT_PATH {}".format(self.certPath))
 
             kwargs = kwargs_from_env(assert_hostname=False)
-            kwargs['timeout'] = 15
+            kwargs['timeout'] = 30
             self.cli = APIClient(**kwargs)
             logging.info("Docker Version {}".format(self.cli.version()))
 


### PR DESCRIPTION
This fixes an issue where docker-forward would exit if new containers were spun up or restarted.  The Error:

08-15-2017 10:16:04 ERROR    404 Client Error: Not Found for url: https://192.168.99.100:2376/v1.24/containers/6b85718fcdccac3de3f160c026f3a1627740cd28e3c1cc7045f483c709c63d5a/json ("No such container: 6b85718fcdccac3de3f160c026f3a1627740cd28e3c1cc7045f483c709c63d5a")
Traceback (most recent call last):
  File "docker-forward", line 209, in run
    for port in self.get_container_port_bindings(event["id"]):
  File "docker-forward", line 137, in get_container_port_bindings
    bindings = self.cli.inspect_container(container)["HostConfig"]["PortBindings"]
  File "/usr/local/lib/python2.7/site-packages/docker/utils/decorators.py", line 21, in wrapped
    return f(self, resource_id, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/docker/api/container.py", line 745, in inspect_container
    self._get(self._url("/containers/{0}/json", container)), True
  File "/usr/local/lib/python2.7/site-packages/docker/api/client.py", line 220, in _result
    self._raise_for_status(response)
  File "/usr/local/lib/python2.7/site-packages/docker/api/client.py", line 216, in _raise_for_status
    raise create_api_error_from_http_exception(e)
  File "/usr/local/lib/python2.7/site-packages/docker/errors.py", line 30, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation)
NotFound: 404 Client Error: Not Found for url: https://192.168.99.100:2376/v1.24/containers/6b85718fcdccac3de3f160c026f3a1627740cd28e3c1cc7045f483c709c63d5a/json ("No such container: 6b85718fcdccac3de3f160c026f3a1627740cd28e3c1cc7045f483c709c63d5a")
