### PR TITLE
Hardcode shebang to python2.7

### DIFF
--- a/docker-forward
+++ b/docker-forward
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import subprocess
 import os


### PR DESCRIPTION
Relying on `python` or `python2` doesn't work when multiple version of python are installed.